### PR TITLE
Support generic configuration of bean-like objects

### DIFF
--- a/support/src/main/scala/com/github/kxbmap/configs/support/std/BeanSupport.scala
+++ b/support/src/main/scala/com/github/kxbmap/configs/support/std/BeanSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Tsukasa Kitachi
+ * Copyright 2015 Philip L. McMahon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,27 @@
 package com.github.kxbmap.configs
 package support.std
 
-trait AllSupport
-  extends FileSupport
-  with PathSupport
-  with NetSupport
-  with BeanSupport
+import scala.collection.JavaConversions._
+
+
+trait BeanSupport {
+
+  object Beans {
+
+    def apply[T](f: => T): Configs[T] = Configs.configs {
+      _.entrySet().foldLeft(f) { (o, e) =>
+        val m = s"set${e.getKey.capitalize}"
+        val v = e.getValue.unwrapped()
+        o.getClass.getMethod(m, v.getClass).invoke(o, v)
+        o
+      }
+    }
+
+    def apply[T: Manifest]: Configs[T] = Beans {
+      implicitly[Manifest[T]].runtimeClass.asInstanceOf[Class[T]].
+        getConstructor().newInstance()
+    }
+
+  }
+
+}

--- a/support/src/main/scala/com/github/kxbmap/configs/support/std/package.scala
+++ b/support/src/main/scala/com/github/kxbmap/configs/support/std/package.scala
@@ -22,6 +22,7 @@ package object std {
   object file extends FileSupport
   object path extends PathSupport
   object net extends NetSupport
+  object bean extends BeanSupport
 
   object all extends AllSupport
 }

--- a/support/src/test/scala/com/github/kxbmap/configs/support/std/BeanSupportSpec.scala
+++ b/support/src/test/scala/com/github/kxbmap/configs/support/std/BeanSupportSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 Philip L. McMahon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.kxbmap.configs
+package support.std
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{FunSpec, Matchers}
+
+class BeanSupportSpec extends FunSpec with Matchers with BeanSupport {
+
+  class Inner extends Obj
+
+  describe("generic bean support") {
+    val c = ConfigFactory.parseString(
+      """a.foo=x
+        |b.bar=1
+        |c.abc=xyz""".stripMargin)
+
+    implicit val topConfigs = Beans[Top]
+    implicit val innerConfigs = Beans { new Inner }
+
+    it ("should be available to get a value with a no-arg constructor") {
+      val o = c.get[Top]("a")
+      o._foo shouldBe "x"
+      o._bar shouldBe null // Omitted from config
+    }
+
+    it ("should return different instances with a no-arg constructor") {
+      c.get[Top]("a") shouldNot be theSameInstanceAs c.get[Top]("a")
+    }
+
+    it ("should be available to get a value via factory function") {
+      val o = c.get[Inner]("a")
+      o._foo shouldBe "x"
+      o._bar shouldBe null
+    }
+
+    it ("should return different instances with factory function") {
+      c.get[Inner]("a") shouldNot be theSameInstanceAs c.get[Inner]("a")
+    }
+
+    it ("should throw an exception for incorrect property types") {
+      intercept[NoSuchMethodException] { c.get[Inner]("b") }
+    }
+
+    it ("should throw an exception for unknown property names") {
+      intercept[NoSuchMethodException] { c.get[Inner]("c") }
+    }
+  }
+
+}
+
+trait Obj {
+
+  var _foo: String = _
+  var _bar: String = _
+
+  def setFoo(s: String): Unit = _foo = s
+  def setBar(s: String): Unit = _bar = s
+
+}
+
+class Top extends Obj


### PR DESCRIPTION
This patch provides a convenient way to instantiate bean-like objects via setter methods matching the property name. I implemented this to simplify creation of Java beans such as `HikariDataSource`.

As an example, given the following configuration:

```
app.db {
  driverClassName = "org.postgresql.Driver"
  jdbcUrl = "jdbc:postgresql://localhost:5432/example"
  username = "example"
  password = "secret"
}
```

Then the following Scala code would create a new HikariCP datasource:

```scala
import com.github.kxbmap.configs.support.std.bean._
implicit val hikariConfigs = Beans[HikariDataSource]
val c = ConfigFactory.load()
val ds = c.get[HikariDataSource]("app.db")
```

If the configuration references a method name which does not exist, a `NoSuchMethodException` will be thrown. While this meets my current needs, a more advanced implementation could throw a `ConfigException` instead and/or integrate with `CatchCond` to allow suppression of exceptions when the requisite setter is not available.

I've done my best to match the style/syntax used elsewhere in the project.