### PR TITLE
Support primitive types when resolving setter method

### DIFF
--- a/support/src/test/scala/com/github/kxbmap/configs/support/std/BeanSupportSpec.scala
+++ b/support/src/test/scala/com/github/kxbmap/configs/support/std/BeanSupportSpec.scala
@@ -17,7 +17,8 @@
 package com.github.kxbmap.configs
 package support.std
 
-import com.typesafe.config.ConfigFactory
+import java.util.{List => JList}
+import com.typesafe.config.{ConfigException, ConfigFactory}
 import org.scalatest.{FunSpec, Matchers}
 
 class BeanSupportSpec extends FunSpec with Matchers with BeanSupport {
@@ -26,17 +27,23 @@ class BeanSupportSpec extends FunSpec with Matchers with BeanSupport {
 
   describe("generic bean support") {
     val c = ConfigFactory.parseString(
-      """a.foo=x
-        |b.bar=1
-        |c.abc=xyz""".stripMargin)
+      """a.string=x
+        |b.int=one
+        |c.missing=prop
+        |d.boolean=true
+        |d.double=0.1
+        |d.int=1
+        |d.list=[foo, bar, baz]
+        |d.long=2
+        |d.string=x""".stripMargin)
 
     implicit val topConfigs = Beans[Top]
     implicit val innerConfigs = Beans { new Inner }
 
     it ("should be available to get a value with a no-arg constructor") {
       val o = c.get[Top]("a")
-      o._foo shouldBe "x"
-      o._bar shouldBe null // Omitted from config
+      o._string shouldBe "x"
+      o._list shouldBe null // Omitted from config
     }
 
     it ("should return different instances with a no-arg constructor") {
@@ -45,8 +52,8 @@ class BeanSupportSpec extends FunSpec with Matchers with BeanSupport {
 
     it ("should be available to get a value via factory function") {
       val o = c.get[Inner]("a")
-      o._foo shouldBe "x"
-      o._bar shouldBe null
+      o._string shouldBe "x"
+      o._list shouldBe null
     }
 
     it ("should return different instances with factory function") {
@@ -54,24 +61,56 @@ class BeanSupportSpec extends FunSpec with Matchers with BeanSupport {
     }
 
     it ("should throw an exception for incorrect property types") {
-      intercept[NoSuchMethodException] { c.get[Inner]("b") }
+      intercept[ConfigException.WrongType] { c.get[Inner]("b") }
     }
 
     it ("should throw an exception for unknown property names") {
-      intercept[NoSuchMethodException] { c.get[Inner]("c") }
+      intercept[ConfigException.BadPath] { c.get[Inner]("c") }
     }
+
+    it ("should support both primitive types and objects") {
+      val o = c.get[Top]("d")
+      o._boolean shouldBe true
+      o._int shouldBe 1
+      o._list should have length 3
+      o._long shouldBe 2
+      o._string shouldBe "x" // Omitted from config
+    }
+
   }
 
 }
 
 trait Obj {
 
-  var _foo: String = _
-  var _bar: String = _
+  var _boolean: Boolean = _
+  var _double: Double = _
+  var _int: Int = _
+  var _list: JList[String] = _
+  var _long: Long = _
+  var _string: String = _
 
-  def setFoo(s: String): Unit = _foo = s
-  def setBar(s: String): Unit = _bar = s
+  def setBoolean(b: Boolean): Unit = _boolean = b
+  def setDouble(d: Double): Unit = _double = d
+  def setInt(i: Int): Unit = _int = i
+  def setList(l: JList[String]): Unit = _list = l
+  def setLong(l: Long): Unit = _long = l
+  def setString(s: String): Unit = _string = s
 
 }
 
 class Top extends Obj
+
+class Primitives {
+
+  var _boolean: Boolean = _
+  var _double: Double = _
+  var _int: Int = _
+  var _long: Long = _
+
+  def setBoolean(b: Boolean): Unit = _boolean = b
+  def setDouble(d: Double): Unit = _double = d
+  def setInt(i: Int): Unit = _int = i
+  def setLong(l: Long): Unit = _long = l
+
+}


### PR DESCRIPTION
This is a bugfix for my previous `Beans` changes (#3) as I did not test setting primitive types on bean-like objects. Without this patch, boxed primitives returned by `ConfigValue#unwrapped()` are not assignable via reflection because the method lookup for `setFoo(Integer)` will not find `setFoo(int)`. Other libraries, such as `ClassUtils` in Apache's commons-lang, have an extensive matching approach to find primitive methods given a boxed type.

To work around the problem and avoid unnecessary library dependencies, the method is looked up by name and arity rather than by name and argument type. The first method found will be invoked "blindly" (the JVM will unbox the argument as necessary). Note that when multiple setters are defined for a given property, which is selected may be non-deterministic. If the invocation fails, a `ConfigException.WrongType` is thrown. This approach should work for most beans, including my intended use with `HikariCPDataSource`, which I expect will have a single setter for a each property.

This patch also includes a check which throws `ConfigException.BadPath` if a setter with the requisite name is not found.

The unit tests have been updated to verify assignment of the following property types:
* `java.lang.Boolean`/`scala.Boolean`
* `java.lang.Double`/`scala.Double`
* `java.lang.Integer`/`scala.Int`
* `java.util.List`
* `java.lang.Long`/`scala.Long`
* `java.lang.String`