### PR TITLE
Add getWithOrigin

### DIFF
--- a/core/src/main/scala/configs/Configs.scala
+++ b/core/src/main/scala/configs/Configs.scala
@@ -341,4 +341,14 @@ sealed abstract class ConfigsInstances extends ConfigsInstances0 {
       p
     }
 
+  implicit def withOriginConfigs[A](implicit A: Configs[A]): Configs[(A, ConfigOrigin)] =
+    (c, p) => A.get(c, p).flatMap { a =>
+      try
+        Result.successful((a, c.getValue(p).origin()))
+      catch {
+        case e: ConfigException.Null => Result.successful((a, e.origin()))
+        case _: ConfigException.Missing => Result.failure(ConfigError(s"no origin for '$p'"))
+      }
+    }
+
 }

--- a/core/src/main/scala/configs/config.scala
+++ b/core/src/main/scala/configs/config.scala
@@ -16,7 +16,8 @@
 
 package configs
 
-import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import com.typesafe.config.{ConfigFactory, ConfigOriginFactory, ConfigValueFactory}
+import java.net.URL
 import scala.collection.JavaConverters._
 import scala.collection.breakOut
 
@@ -109,5 +110,17 @@ object ConfigUtil {
 
   def splitPath(path: String): List[String] =
     Impl.splitPath(path).asScala.toList
+
+}
+
+object ConfigOrigin {
+
+  def default: ConfigOrigin = ConfigOriginFactory.newSimple()
+
+  def simple(description: String): ConfigOrigin = ConfigOriginFactory.newSimple(description)
+
+  def file(filename: String): ConfigOrigin = ConfigOriginFactory.newFile(filename)
+
+  def url(url: URL): ConfigOrigin = ConfigOriginFactory.newURL(url)
 
 }

--- a/core/src/main/scala/configs/package.scala
+++ b/core/src/main/scala/configs/package.scala
@@ -26,4 +26,6 @@ package object configs {
 
   type MemorySize = com.typesafe.config.ConfigMemorySize
 
+  type ConfigOrigin = com.typesafe.config.ConfigOrigin
+
 }

--- a/core/src/main/scala/configs/syntax/package.scala
+++ b/core/src/main/scala/configs/syntax/package.scala
@@ -32,6 +32,9 @@ package object syntax {
     def getOrElse[A](path: String, default: => A)(implicit A: Configs[Option[A]]): Result[A] =
       get(path)(A).map(_.getOrElse(default))
 
+    def getWithOrigin[A: Configs](path: String): Result[(A, ConfigOrigin)] =
+      get[(A, ConfigOrigin)](path)
+
     def ++(that: Config): Config =
       that.withFallback(self)
 

--- a/core/src/test/scala/configs/instance/WithOriginTest.scala
+++ b/core/src/test/scala/configs/instance/WithOriginTest.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2016 Tsukasa Kitachi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package configs.instance
+
+import com.typesafe.config.ConfigFactory
+import configs.{Config, ConfigError, ConfigOrigin, Configs, Result}
+import scalaprops.Property.forAll
+import scalaprops.Scalaprops
+
+object WithOriginTest extends Scalaprops {
+
+  val value = forAll { n: Int =>
+    val config = ConfigFactory.parseString(s"a = $n")
+    Configs[(Int, ConfigOrigin)].get(config, "a") ==
+      Result.successful((n, ConfigOrigin.simple("String").withLineNumber(1)))
+  }
+
+  val `null` = forAll {
+    val config = ConfigFactory.parseString("a = null")
+    Configs[(Option[Int], ConfigOrigin)].get(config, "a") ==
+      Result.successful((None, ConfigOrigin.simple("String").withLineNumber(1)))
+  }
+
+  val missing = forAll {
+    Configs[(Option[Int], ConfigOrigin)].get(Config.empty, "a") ==
+      Result.failure(ConfigError("no origin for 'a'").pushPath("a"))
+  }
+
+}

--- a/core/src/test/scala/configs/syntax/EnrichConfigTest.scala
+++ b/core/src/test/scala/configs/syntax/EnrichConfigTest.scala
@@ -19,7 +19,7 @@ package configs.syntax
 import com.typesafe.config.ConfigFactory
 import configs.testutil.instance.config._
 import configs.testutil.instance.string._
-import configs.{Config, ConfigObject, Result, ToConfig}
+import configs.{Config, ConfigObject, ConfigOrigin, Result, ToConfig}
 import scala.collection.JavaConverters._
 import scalaprops.Property.forAll
 import scalaprops.Scalaprops
@@ -41,6 +41,11 @@ object EnrichConfigTest extends Scalaprops {
   val getOrElse = forAll { (n: Option[Int], m: Int) =>
     val config = ToConfig[Option[Int]].toValue(n).atKey("path")
     config.getOrElse[Int]("path", m) == Result.successful(n.getOrElse(m))
+  }
+
+  val getWithOrigin = forAll { n: Int =>
+    val config = ConfigFactory.parseString(s"path = $n")
+    config.getWithOrigin[Int]("path") == Result.successful((n, ConfigOrigin.simple("String").withLineNumber(1)))
   }
 
   val ++ = forAll { (c1: Config, c2: Config) =>


### PR DESCRIPTION
Fix #13 

`config.getWithOrigin[A](path)` is alias for `config.get[(A, ConfigOrigin)](path)`
