### PR TITLE
Illustrate the usage of ~ operator in README

### DIFF
--- a/docs/src/tut/doc/README.md
+++ b/docs/src/tut/doc/README.md
@@ -111,6 +111,28 @@ val config = ConfigFactory.parseString("""
 config.extract[MyConfig]
 ```
 
+You may use the `~` operator to combine multiple results and apply a function with the results passed as arguments, this is useful when you want to construct a complex case class from several config extractors.
+
+```tut:silent
+import configs.syntax._
+
+case class ServiceConfig(name: String, port: Int, hosts: List[String])
+
+val config = ConfigFactory.parseString(
+  """
+    |name = "foo"
+    |port = 9876
+    |hosts = ["localhost", "foo.com"]
+  """.stripMargin)
+```
+```tut
+(
+  config.get[String]("name") ~
+  config.get[Int]("port") ~
+  config.get[List[String]]("hosts")
+)(ServiceConfig) // Alternatively (name, port, hosts) => ServerConfig(name, port, posts)
+```
+
 Supported types
 ---------------
 


### PR DESCRIPTION
Hi, I find your implementation of applicative style result builder very cool and useful for my use cases, however, it's not written in README and not obvious for most users. I wonder if there are some reasons for not exposing this feature. If it's ok to make this feature public, here I added a small section in README to reveal the hidden treasure to help others :) 

I notice that some upgrading work is in progress so the target README is not submitted.