### PR TITLE
avoid collection.breakOut

### DIFF
--- a/core/src/main/scala/configs/ConfigReader.scala
+++ b/core/src/main/scala/configs/ConfigReader.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit
 import java.{lang => jl, math => jm, time => jt, util => ju}
 import scala.annotation.compileTimeOnly
 import scala.collection.JavaConverters._
-import scala.collection.breakOut
 import scala.collection.generic.CanBuildFrom
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
@@ -194,7 +193,7 @@ sealed abstract class ConfigReaderInstances extends ConfigReaderInstances0 {
         Result.traverse(c.root().asScala.keysIterator) { k =>
           val p = ConfigUtil.joinPath(k)
           Result.tuple2(A.fromString(k).pushPath(p), B.read(c, p))
-        }(breakOut)
+        }.map(_.toMap)
       m.map(_.asJava)
     }
 

--- a/core/src/main/scala/configs/ConfigWriter.scala
+++ b/core/src/main/scala/configs/ConfigWriter.scala
@@ -20,7 +20,6 @@ import com.typesafe.config.ConfigValueFactory
 import java.{lang => jl, math => jm, time => jt, util => ju}
 import scala.annotation.compileTimeOnly
 import scala.collection.JavaConverters._
-import scala.collection.breakOut
 import scala.concurrent.duration._
 
 trait ConfigWriter[A] {
@@ -223,7 +222,7 @@ sealed abstract class ConfigWriterInstances extends ConfigWriterInstances0 {
 
 
   implicit def iterableConfigWriter[F[X] <: Iterable[X], A](implicit A: ConfigWriter[A]): ConfigWriter[F[A]] =
-    xs => ConfigList.fromSeq(xs.map(A.write)(breakOut)).value
+    xs => ConfigList.fromSeq(xs.map(A.write).toSeq).value
 
   implicit def charIterableConfigWriter[F[X] <: Iterable[X]]: ConfigWriter[F[Char]] =
     ConfigWriter.by(cs => new String(cs.toArray))
@@ -239,7 +238,7 @@ sealed abstract class ConfigWriterInstances extends ConfigWriterInstances0 {
 
 
   implicit def mapConfigWriter[M[X, Y] <: collection.Map[X, Y], A, B](implicit A: StringConverter[A], B: ConfigWriter[B]): ConfigWriter[M[A, B]] =
-    m => ConfigObject.fromMap(m.map(t => (A.toString(t._1), B.write(t._2)))(breakOut)).value
+    m => ConfigObject.fromMap(m.map(t => (A.toString(t._1), B.write(t._2))).toMap).value
 
   implicit def javaMapConfigWriter[M[X, Y] <: ju.Map[X, Y], A: StringConverter, B: ConfigWriter]: ConfigWriter[M[A, B]] =
     ConfigWriter.by(_.asScala)

--- a/core/src/test/scala/configs/ResultTest.scala
+++ b/core/src/test/scala/configs/ResultTest.scala
@@ -19,7 +19,6 @@ package configs
 import configs.testutil.instance.anyVal._
 import configs.testutil.instance.result._
 import configs.testutil.instance.string._
-import scala.collection.breakOut
 import scalaprops.Property._
 import scalaprops.{Properties, Scalaprops, scalazlaws}
 import scalaz.std.list._
@@ -42,10 +41,6 @@ object ResultTest extends Scalaprops {
     Properties.list(
       Properties.single("list", forAll { (xs: List[Int], f: Int => Result[Long]) =>
         Result.traverse(xs)(f) == Traverse[List].traverse(xs)(f)
-      }),
-      Properties.single("breakOut", forAll { m0: Map[Int, Long] =>
-        val m: Result[Map[Int, Long]] = Result.traverse(m0)(Result.successful)(breakOut)
-        m.exists(_ == m0)
       })
     )
   }
@@ -55,10 +50,6 @@ object ResultTest extends Scalaprops {
     Properties.list(
       Properties.single("list", forAll { xs: List[Result[Int]] =>
         Result.sequence(xs) == Traverse[List].sequence(xs)
-      }),
-      Properties.single("breakOut", forAll { m0: Map[Int, Long] =>
-        val m: Result[Map[Int, Long]] = Result.sequence(m0.map(Result.successful))(breakOut)
-        m.exists(_ == m0)
       })
     )
   }


### PR DESCRIPTION
`collection.breakOut` deleted since Scala 2.13