### PR TITLE
fix compile error in latest Scala 2.13

### DIFF
--- a/core/src/test/scala/configs/instance/BigNumberTypesTest.scala
+++ b/core/src/test/scala/configs/instance/BigNumberTypesTest.scala
@@ -28,7 +28,7 @@ object BigNumberTypesTest extends Scalaprops {
   val bigInt = check[BigInt]
 
   val bigIntFromDecimal = forAll { d: BigDecimal =>
-    ConfigReader[BigInt].extractValue(ConfigWriter[BigDecimal].write(d)).contains(d.toBigInt())
+    ConfigReader[BigInt].extractValue(ConfigWriter[BigDecimal].write(d)).contains(d.toBigInt)
   }
 
   val bigInteger = check[jm.BigInteger]


### PR DESCRIPTION
- https://github.com/scala/scala/commit/f5c102e72fbd835bf66377879bdb8be20d882da1#diff-c43eaee4c77b8bc2d2a5ca4fe304530fL700
- https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/1286/consoleFull

```
[kxbmap-configs] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.12/project-builds/kxbmap-configs-1b84d6c4fe56440e3a48c8908ce67e1203872ba9/core/src/test/scala/configs/instance/BigNumberTypesTest.scala:31:93: scala.math.BigInt does not take parameters
[kxbmap-configs] [error]     ConfigReader[BigInt].extractValue(ConfigWriter[BigDecimal].write(d)).contains(d.toBigInt())
[kxbmap-configs] [error]                                                                                             ^
[kxbmap-configs] [error] one error found
```