### PR TITLE
fix compile error with latest Scala 2.13.x

### DIFF
--- a/core/src/main/scala/configs/Result.scala
+++ b/core/src/main/scala/configs/Result.scala
@@ -48,7 +48,7 @@ sealed abstract class Result[+A] extends Product with Serializable {
   def handleWith[B >: A](pf: PartialFunction[ConfigError, Result[B]]): Result[B]
 
   final def handle[B >: A](pf: PartialFunction[ConfigError, B]): Result[B] =
-    handleWith(pf.andThen(Result.successful))
+    handleWith(pf.andThen(Result.successful(_)))
 
   def mapError(f: ConfigError => ConfigError): Result[A]
 


### PR DESCRIPTION
```
[kxbmap-configs] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.16/project-builds/kxbmap-configs-412278979d2102f1e498033a609bab9525b7ae2d/core/src/main/scala/configs/Result.scala:51:34: missing argument list for method successful in object Result
[kxbmap-configs] [error] Unapplied methods are only converted to functions when a function type is expected.
[kxbmap-configs] [error] You can make this conversion explicit by writing `successful _` or `successful(_)` instead of `successful`.
[kxbmap-configs] [error]     handleWith(pf.andThen(Result.successful))
[kxbmap-configs] [error]                                  ^
[kxbmap-configs] [error] one error found
```