### PR TITLE
Feature/multiple naming strategies

### DIFF
--- a/core/src/main/scala/configs/ConfigKeyNaming.scala
+++ b/core/src/main/scala/configs/ConfigKeyNaming.scala
@@ -19,17 +19,17 @@ package configs
 import configs.ConfigUtil.splitWords
 import java.util.Locale
 
-trait ConfigKeyNaming[A] {
+trait ConfigKeyNaming[A] { self =>
 
   def apply(field: String): Seq[String]
 
   def applyFirst(field: String): String = apply(field).head
 
   def andThen(f: String => Seq[String]): ConfigKeyNaming[A] =
-    field => apply(field).flatMap(f)
+    field => self.apply(field).flatMap(f)
 
   def or(f: String => Seq[String]): ConfigKeyNaming[A] =
-    field => apply(field) ++ f(field)
+    field => self.apply(field) ++ f(field)
 }
 
 object ConfigKeyNaming {

--- a/core/src/main/scala/configs/ConfigKeyNaming.scala
+++ b/core/src/main/scala/configs/ConfigKeyNaming.scala
@@ -21,11 +21,15 @@ import java.util.Locale
 
 trait ConfigKeyNaming[A] {
 
-  def apply(field: String): String
+  def apply(field: String): Seq[String]
 
-  def andThen(f: String => String): ConfigKeyNaming[A] =
-    field => f(apply(field))
+  def applyFirst(field: String): String = apply(field).head
 
+  def andThen(f: String => Seq[String]): ConfigKeyNaming[A] =
+    field => apply(field).flatMap(f)
+
+  def or(f: String => Seq[String]): ConfigKeyNaming[A] =
+    field => apply(field) ++ f(field)
 }
 
 object ConfigKeyNaming {
@@ -38,37 +42,37 @@ object ConfigKeyNaming {
     _identity.asInstanceOf[ConfigKeyNaming[A]]
 
   private[this] val _identity: ConfigKeyNaming[Any] =
-    x => x
+    x => Seq(x)
 
 
   def hyphenSeparated[A]: ConfigKeyNaming[A] =
     _hyphenSeparated.asInstanceOf[ConfigKeyNaming[A]]
 
   private[this] val _hyphenSeparated: ConfigKeyNaming[Any] =
-    splitWords(_).mkString("-").toLowerCase(Locale.ROOT)
+    x => Seq(splitWords(x).mkString("-").toLowerCase(Locale.ROOT))
 
 
   def snakeCase[A]: ConfigKeyNaming[A] =
     _snakeCase.asInstanceOf[ConfigKeyNaming[A]]
 
   private[this] val _snakeCase: ConfigKeyNaming[Any] =
-    splitWords(_).mkString("_").toLowerCase(Locale.ROOT)
+    x => Seq(splitWords(x).mkString("_").toLowerCase(Locale.ROOT))
 
 
   def lowerCamelCase[A]: ConfigKeyNaming[A] =
     _lowerCamelCase.asInstanceOf[ConfigKeyNaming[A]]
 
   private[this] val _lowerCamelCase: ConfigKeyNaming[Any] =
-    splitWords(_) match {
+    x => Seq(splitWords(x) match {
       case Nil => ""
       case h :: t => (h.toLowerCase(Locale.ROOT) :: t.map(_.capitalize)).mkString
-    }
+    })
 
 
   def upperCamelCase[A]: ConfigKeyNaming[A] =
     _upperCamelCase.asInstanceOf[ConfigKeyNaming[A]]
 
   private[this] val _upperCamelCase: ConfigKeyNaming[Any] =
-    splitWords(_).map(_.capitalize).mkString
+    x => Seq(splitWords(x).map(_.capitalize).mkString)
 
 }

--- a/core/src/main/scala/configs/macros/ConfigReaderMacro.scala
+++ b/core/src/main/scala/configs/macros/ConfigReaderMacro.scala
@@ -56,6 +56,9 @@ private[macros] trait ConfigReaderMacroImpl {
 
   class DerivingReaderContext(val naming: Tree, val cache: ConfigReaderCache) extends DerivingContext {
     type Cache = ConfigReaderCache
+
+    // for reading we take the all names produced by ConfigKeyNaming
+    def configKey(field: String): Tree = q"$n.apply($field)"
   }
 
   class ConfigReaderCache extends InstanceCache {

--- a/core/src/main/scala/configs/macros/ConfigWriterMacro.scala
+++ b/core/src/main/scala/configs/macros/ConfigWriterMacro.scala
@@ -48,6 +48,9 @@ private[macros] trait ConfigWriterMacroImpl {
 
   class DerivingWriterContext(val naming: Tree, val cache: ConfigWriterCache) extends DerivingContext {
     type Cache = ConfigWriterCache
+
+    // for writing we take the first name produced by ConfigKeyNaming
+    def configKey(field: String): Tree = q"$n.applyFirst($field)"
   }
 
   class ConfigWriterCache extends InstanceCache {

--- a/core/src/main/scala/configs/macros/Construct.scala
+++ b/core/src/main/scala/configs/macros/Construct.scala
@@ -103,13 +103,10 @@ trait Construct {
     val params =
       tpe.decls.collectFirst {
         case m: MethodSymbol if m.isPrimaryConstructor =>
-          if (m.paramLists.lengthCompare(1) <= 0) {
-            val ds = defaults(a, m)
-            m.paramLists.flatten.zipWithIndex.map {
-              case (s, i) => Param(s, ds.get(i))
-            }
+          val ds = defaults(a, m)
+          m.paramLists.head.zipWithIndex.map {
+            case (s, i) => Param(s, ds.get(i))
           }
-          else abort(a, "primary constructor has multi param list")
       }.getOrElse(abort(a, "bug?"))
     val accessors =
       tpe.decls.sorted.collect {

--- a/core/src/main/scala/configs/macros/Construct.scala
+++ b/core/src/main/scala/configs/macros/Construct.scala
@@ -104,6 +104,7 @@ trait Construct {
       tpe.decls.collectFirst {
         case m: MethodSymbol if m.isPrimaryConstructor =>
           val ds = defaults(a, m)
+          // only use first parameter list of case class constructor
           m.paramLists.head.zipWithIndex.map {
             case (s, i) => Param(s, ds.get(i))
           }

--- a/core/src/main/scala/configs/macros/MacroBase.scala
+++ b/core/src/main/scala/configs/macros/MacroBase.scala
@@ -64,9 +64,9 @@ private[macros] abstract class MacroBase {
 
     def naming: Tree
 
-    private[this] val n = freshName("n")
+    protected val n = freshName("n")
 
-    def configKey(field: String): Tree = q"$n($field)"
+    def configKey(field: String): Tree
 
     def valDefs: List[Tree] = {
       val nv = q"val $n = $naming"

--- a/core/src/test/scala/configs/ConfigKeyNamingTest.scala
+++ b/core/src/test/scala/configs/ConfigKeyNamingTest.scala
@@ -16,11 +16,11 @@
 
 package configs
 
-import configs.testutil.fun._
 import scalaprops.Property.forAll
 import scalaprops.{Gen, Scalaprops}
 import scalaprops.ScalapropsScalaz._
 import scalaz.syntax.apply._
+import collection.JavaConverters._
 
 object ConfigKeyNamingTest extends Scalaprops {
 
@@ -36,13 +36,8 @@ object ConfigKeyNamingTest extends Scalaprops {
     implicit val naming: ConfigKeyNaming[User] = ConfigKeyNaming.identity
 
     forAll { user: User =>
-      val expected =
-        s"""emailAddress=${user.emailAddress}
-           |name=${user.name}
-           |siteURL=${user.siteURL}
-           |""".stripMargin
-
-      render(user) == expected
+      val result = ConfigWriter[User].write(user).asInstanceOf[ConfigObject]
+      result.keySet().asScala == Set("emailAddress", "name", "siteURL")
     }
   }
 
@@ -50,13 +45,8 @@ object ConfigKeyNamingTest extends Scalaprops {
     implicit val naming: ConfigKeyNaming[User] = ConfigKeyNaming.hyphenSeparated
 
     forAll { user: User =>
-      val expected =
-        s"""email-address=${user.emailAddress}
-           |name=${user.name}
-           |site-url=${user.siteURL}
-           |""".stripMargin
-
-      render(user) == expected
+      val result = ConfigWriter[User].write(user).asInstanceOf[ConfigObject]
+      result.keySet().asScala == Set("email-address", "name", "site-url")
     }
   }
 
@@ -64,13 +54,8 @@ object ConfigKeyNamingTest extends Scalaprops {
     implicit val naming: ConfigKeyNaming[User] = ConfigKeyNaming.snakeCase
 
     forAll { user: User =>
-      val expected =
-        s""""email_address"=${user.emailAddress}
-           |name=${user.name}
-           |"site_url"=${user.siteURL}
-           |""".stripMargin
-
-      render(user) == expected
+      val result = ConfigWriter[User].write(user).asInstanceOf[ConfigObject]
+      result.keySet().asScala == Set("email_address", "name", "site_url")
     }
   }
 
@@ -78,13 +63,8 @@ object ConfigKeyNamingTest extends Scalaprops {
     implicit val naming: ConfigKeyNaming[User] = ConfigKeyNaming.lowerCamelCase
 
     forAll { user: User =>
-      val expected =
-        s"""emailAddress=${user.emailAddress}
-           |name=${user.name}
-           |siteURL=${user.siteURL}
-           |""".stripMargin
-
-      render(user) == expected
+      val result = ConfigWriter[User].write(user).asInstanceOf[ConfigObject]
+      result.keySet().asScala == Set("emailAddress", "name", "siteURL")
     }
   }
 
@@ -92,28 +72,18 @@ object ConfigKeyNamingTest extends Scalaprops {
     implicit val naming: ConfigKeyNaming[User] = ConfigKeyNaming.upperCamelCase
 
     forAll { user: User =>
-      val expected =
-        s"""EmailAddress=${user.emailAddress}
-           |Name=${user.name}
-           |SiteURL=${user.siteURL}
-           |""".stripMargin
-
-      render(user) == expected
+      val result = ConfigWriter[User].write(user).asInstanceOf[ConfigObject]
+      result.keySet().asScala == Set("EmailAddress", "Name", "SiteURL")
     }
   }
 
   val andThen = {
     implicit val naming: ConfigKeyNaming[User] =
-      ConfigKeyNaming.hyphenSeparated.andThen("user-" + _)
+      ConfigKeyNaming.hyphenSeparated.andThen(x => Seq("user-" + x))
 
     forAll { user: User =>
-      val expected =
-        s"""user-email-address=${user.emailAddress}
-           |user-name=${user.name}
-           |user-site-url=${user.siteURL}
-           |""".stripMargin
-
-      render(user) == expected
+      val result = ConfigWriter[User].write(user).asInstanceOf[ConfigObject]
+      result.keySet().asScala == Set("user-email-address", "user-name", "user-site-url")
     }
   }
 

--- a/core/src/test/scala/configs/DeriveForBeanTest.scala
+++ b/core/src/test/scala/configs/DeriveForBeanTest.scala
@@ -22,6 +22,7 @@ import configs.testutil.instance.anyVal._
 import configs.testutil.instance.tuple._
 import configs.testutil.{Bean1, Bean22, Bean484}
 import java.util.Objects
+
 import scala.beans.{BeanProperty, BooleanBeanProperty}
 import scalaprops.Property.forAll
 import scalaprops.{Gen, Lazy, Properties, Scalaprops}
@@ -29,6 +30,7 @@ import scalaprops.ScalapropsScalaz._
 import scalaz.syntax.apply._
 import scalaz.syntax.equal._
 import scalaz.Equal
+import collection.JavaConverters._
 
 object DeriveForBeanTest extends Scalaprops {
 
@@ -143,13 +145,8 @@ object DeriveForBeanTest extends Scalaprops {
     implicit val naming: ConfigKeyNaming[Foo] = ConfigKeyNaming.identity
 
     forAll { foo: Foo =>
-      val expected =
-        s"""URL=${foo.getURL}
-           |fooBah=${foo.getFooBah}
-           |x=${foo.getX}
-           |""".stripMargin
-
-      render(foo) == expected
+      val result = ConfigWriter[Foo].write(foo).asInstanceOf[ConfigObject]
+      result.unwrapped.asScala.toSet == Set("URL" -> foo.getURL, "fooBah" -> foo.getFooBah, "x" -> foo.getX)
     }
   }
 
@@ -165,12 +162,8 @@ object DeriveForBeanTest extends Scalaprops {
       (Gen[Boolean] |@| Gen[Boolean])(new BooleanProps(_, _))
 
     forAll { bool: BooleanProps =>
-      val expected =
-        s"""primitive=${bool.isPrimitive}
-           |wrapped=${bool.isWrapped}
-           |""".stripMargin
-
-      render(bool) == expected
+      val result = ConfigWriter[BooleanProps].write(bool).asInstanceOf[ConfigObject]
+      result.unwrapped.asScala.toSet == Set("primitive" -> bool.isPrimitive, "wrapped" -> bool.isWrapped)
     }
   }
 
@@ -183,11 +176,8 @@ object DeriveForBeanTest extends Scalaprops {
     }
 
     forAll {
-      val expected =
-        s"""boolean=true
-           |""".stripMargin
-
-      render(new Foo()) == expected
+      val result = ConfigWriter[Foo].write(new Foo()).asInstanceOf[ConfigObject]
+      result.unwrapped.asScala.toSet == Set("boolean" -> true.asInstanceOf[AnyRef])
     }
   }
 

--- a/core/src/test/scala/configs/DeriveTest.scala
+++ b/core/src/test/scala/configs/DeriveTest.scala
@@ -26,6 +26,14 @@ import scalaprops.{Gen, Lazy, Properties, Scalaprops}
 import scalaprops.ScalapropsScalaz._
 import scalaz.{Apply, Equal}
 
+// Note:
+// the following case class needs to be declared outside and before DeriveTest object, because otherwise the generation
+// of default value functions in scala 2.11 might occur after macro expansion
+case class OptionDefault(opt: Option[Int] = Some(42))
+object OptionDefault {
+  implicit lazy val equal: Equal[OptionDefault] =
+    Equal.equalA[OptionDefault]
+}
 
 object DeriveTest extends Scalaprops {
 
@@ -144,14 +152,6 @@ object DeriveTest extends Scalaprops {
       check[Default1]("w/ default")
     }
     p1 x p2
-  }
-
-
-  case class OptionDefault(opt: Option[Int] = Some(42))
-
-  object OptionDefault {
-    implicit lazy val equal: Equal[OptionDefault] =
-      Equal.equalA[OptionDefault]
   }
 
   val optionDefault = {

--- a/core/src/test/scala/configs/instance/CaseClassTypesTest.scala
+++ b/core/src/test/scala/configs/instance/CaseClassTypesTest.scala
@@ -1,0 +1,26 @@
+package configs.instance
+
+import com.typesafe.config.ConfigFactory
+import configs.{ConfigKeyNaming, ConfigReader}
+import scalaprops.Property.forAll
+import scalaprops.Scalaprops
+
+object CaseClassTypesTest extends Scalaprops {
+
+  case class TestClass(myAttr1: String, myAttr2: String)
+
+  val caseClassMultiNaming = {
+    implicit val naming = ConfigKeyNaming.lowerCamelCase[TestClass].or(ConfigKeyNaming.hyphenSeparated[TestClass].apply)
+    forAll {
+      val reader = ConfigReader.derive[TestClass](naming)
+      val configStr = """
+          my-attr-1 = test
+          myAttr2 = test
+      """
+      val config = ConfigFactory.parseString(configStr)
+      val d = reader.extract(config)
+      println(d)
+      d.isSuccess
+    }
+  }
+}

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -35,6 +35,7 @@ object Common extends AutoPlugin {
       "-language:higherKinds",
       "-language:implicitConversions",
       "-language:experimental.macros"
+      //"-Ymacro-debug-lite"
     ),
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.13


### PR DESCRIPTION
Dear @kxbmap,

I really like your scala hocon config wrapper, but i'm not sure if you still maintain it. Version 0.5.0-SNAPSHOT is a nice refactoring, will there be a release soon?
I created the following PR which adds a feature which worked in 0.4.4 but no longer in 0.5.0. We like to combine multiple naming strategies, as our customers like to mix lowerCamelCase and hyphenSeparated in the same config object...

With this PR its possible to combine multiple ConfigKeyNaming's as follows:
ConfigKeyNaming.lowerCamelCase[A].or(ConfigKeyNaming.hyphenSeparated[A].apply)

Please let me know if you would support this or if you wish any changes.

Thanks and best regard, Zach


