### PR TITLE
fix reducing results from multiple naming stragegies for optional attributes

### DIFF
--- a/core/src/main/scala/configs/ConfigKeyNaming.scala
+++ b/core/src/main/scala/configs/ConfigKeyNaming.scala
@@ -29,7 +29,7 @@ trait ConfigKeyNaming[A] { self =>
     field => self.apply(field).flatMap(f)
 
   def or(f: String => Seq[String]): ConfigKeyNaming[A] =
-    field => self.apply(field) ++ f(field)
+    field => (self.apply(field) ++ f(field)).distinct
 }
 
 object ConfigKeyNaming {

--- a/core/src/test/scala/configs/instance/CaseClassTypesTest.scala
+++ b/core/src/test/scala/configs/instance/CaseClassTypesTest.scala
@@ -5,9 +5,13 @@ import configs.{ConfigKeyNaming, ConfigReader}
 import scalaprops.Property.forAll
 import scalaprops.Scalaprops
 
-object CaseClassTypesTest extends Scalaprops {
+case class TestClass(myAttr1: String, myAttr2: String, testSeal: Option[TestSeal])
+case class ComplexClass(complexAttr: TestClass, myAttr3: String, myAttr4: String)
+sealed trait TestSeal
+case class Seal1(myAttr1: Option[String] = None, myAttr2: String) extends TestSeal
+case class Seal0() extends TestSeal
 
-  case class TestClass(myAttr1: String, myAttr2: String)
+object CaseClassTypesTest extends Scalaprops {
 
   val caseClassMultiNaming = {
     implicit val naming = ConfigKeyNaming.lowerCamelCase[TestClass].or(ConfigKeyNaming.hyphenSeparated[TestClass].apply)
@@ -19,8 +23,36 @@ object CaseClassTypesTest extends Scalaprops {
       """
       val config = ConfigFactory.parseString(configStr)
       val d = reader.extract(config)
-      println(d)
-      d.isSuccess
+      d.isSuccess &&
+        d.value.myAttr1.contains("test") &&
+        d.value.myAttr2.contains("test")
+    }
+  }
+
+  val caseClassComplexMultiNaming = {
+    // generic default naming
+    implicit def myDefaultNaming[A]: ConfigKeyNaming[A] =
+      ConfigKeyNaming.hyphenSeparated[A].or(ConfigKeyNaming.lowerCamelCase[A].apply)
+    forAll {
+      val reader = ConfigReader.derive[ComplexClass]
+      val configStr = """
+          complexAttr = {
+            my-attr-1 = test
+            myAttr2 = test
+            test-seal = {
+              type = Seal1
+              myAttr1 = test
+              my-attr-2 = test
+            }
+          }
+          my-attr-3 = test
+          myAttr4 = test
+      """
+      val config = ConfigFactory.parseString(configStr)
+      val d = reader.extract(config)
+      d.isSuccess &&
+        d.value.complexAttr.testSeal.get.asInstanceOf[Seal1].myAttr1.contains("test") &&
+        d.value.complexAttr.testSeal.get.asInstanceOf[Seal1].myAttr2.contains("test")
     }
   }
 }


### PR DESCRIPTION
Reader for Option[A] must consider how to combine empty results for different naming strategies.