### PR TITLE
Feature: fail on superfluous keys

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val core = project
     compileOrder := CompileOrder.JavaThenScala,
     libraryDependencies ++= Seq(
       typesafeConfig,
+      commonsText,
       scalaCollectionCompat,
       scalaReflect.value % Provided,
       lombok % Test

--- a/core/src/main/scala/configs/ConfigKeyNaming.scala
+++ b/core/src/main/scala/configs/ConfigKeyNaming.scala
@@ -29,7 +29,17 @@ trait ConfigKeyNaming[A] { self =>
     field => self.apply(field).flatMap(f)
 
   def or(f: String => Seq[String]): ConfigKeyNaming[A] =
-    field => self.apply(field) ++ f(field)
+    field => (self.apply(field) ++ f(field)).distinct
+
+  /**
+   * Enable fail on parsing an object and there are superfluous keys in the config
+   */
+  def withFailOnSuperfluousKeys(): ConfigKeyNaming[A] = {
+    failOnSuperfluousKeys = true
+    this
+  }
+
+  var failOnSuperfluousKeys: Boolean = false
 }
 
 object ConfigKeyNaming {

--- a/core/src/main/scala/configs/macros/Construct.scala
+++ b/core/src/main/scala/configs/macros/Construct.scala
@@ -60,7 +60,7 @@ trait Construct {
   private def sealedClass(a: ClassSymbol): Target = {
     def member(a: ClassSymbol): SealedMember =
       if (a.isModuleClass) CaseObject(a.toType, a.module.asModule)
-      else caseClass(a)
+      else caseClass(a, isSealedMember = true)
 
     @annotation.tailrec
     def collect(css: List[ClassSymbol], acc: List[SealedMember]): List[SealedMember] = css match {
@@ -98,7 +98,7 @@ trait Construct {
       case _ => Map.empty
     }
 
-  private def caseClass(a: ClassSymbol): CaseClass = {
+  private def caseClass(a: ClassSymbol, isSealedMember: Boolean = false): CaseClass = {
     val tpe = a.toType
     val params =
       tpe.decls.collectFirst {

--- a/core/src/main/scala/configs/macros/MacroBase.scala
+++ b/core/src/main/scala/configs/macros/MacroBase.scala
@@ -25,8 +25,6 @@ private[macros] abstract class MacroBase {
 
   import c.universe._
 
-  val TypeKey = "type"
-
 
   def tqTuple(args: Seq[Type]): Tree = tq"(..$args)"
 
@@ -67,7 +65,7 @@ private[macros] abstract class MacroBase {
 
     def naming: Tree
 
-    protected val n = freshName("n")
+    protected val n: TermName = freshName("n")
 
     def configKey(field: String): Tree
 

--- a/core/src/main/scala/configs/macros/package.scala
+++ b/core/src/main/scala/configs/macros/package.scala
@@ -22,6 +22,8 @@ package object macros {
   final val MaxTupleSize = 22
   final val MaxSize = MaxApplySize * MaxTupleSize
 
+  final val TypeKey = "type"
+
   def grouping[A](xs: List[A]): List[List[A]] = {
     val n = xs.length
     val t = (n + MaxTupleSize - 1) / MaxTupleSize

--- a/core/src/test/scala/configs/instance/CaseClassTypesTest.scala
+++ b/core/src/test/scala/configs/instance/CaseClassTypesTest.scala
@@ -1,13 +1,18 @@
 package configs.instance
 
 import com.typesafe.config.ConfigFactory
+import configs.Result.Failure
 import configs.{ConfigKeyNaming, ConfigReader}
 import scalaprops.Property.forAll
 import scalaprops.Scalaprops
 
-object CaseClassTypesTest extends Scalaprops {
+case class TestClass(myAttr1: String, myAttr2: String, testSeal: Option[TestSeal])
+case class ComplexClass(complexAttr: TestClass, myAttr3: String, myAttr4: String)
+sealed trait TestSeal
+case class Seal1(myAttr1: Option[String] = None, myAttr2: String) extends TestSeal
+case class Seal0() extends TestSeal
 
-  case class TestClass(myAttr1: String, myAttr2: String)
+object CaseClassTypesTest extends Scalaprops {
 
   val caseClassMultiNaming = {
     implicit val naming = ConfigKeyNaming.lowerCamelCase[TestClass].or(ConfigKeyNaming.hyphenSeparated[TestClass].apply)
@@ -19,8 +24,162 @@ object CaseClassTypesTest extends Scalaprops {
       """
       val config = ConfigFactory.parseString(configStr)
       val d = reader.extract(config)
-      println(d)
-      d.isSuccess
+      d.isSuccess &&
+        d.value.myAttr1.contains("test") &&
+        d.value.myAttr2.contains("test")
+    }
+  }
+
+  val caseClassComplexMultiNaming = {
+    // generic default naming
+    implicit def myDefaultNaming[A]: ConfigKeyNaming[A] =
+      ConfigKeyNaming.hyphenSeparated[A].or(ConfigKeyNaming.lowerCamelCase[A].apply)
+        .withFailOnSuperfluousKeys()
+    forAll {
+      val reader = ConfigReader.derive[ComplexClass]
+      val configStr = """
+          complexAttr = {
+            my-attr-1 = test
+            myAttr2 = test
+            test-seal = {
+              type = Seal1
+              myAttr1 = test
+              my-attr-2 = test
+            }
+          }
+          my-attr-3 = test
+          myAttr4 = test
+      """
+      val config = ConfigFactory.parseString(configStr)
+      val d = reader.extract(config)
+      d.isSuccess &&
+        d.value.complexAttr.testSeal.get.asInstanceOf[Seal1].myAttr1.contains("test") &&
+        d.value.complexAttr.testSeal.get.asInstanceOf[Seal1].myAttr2.contains("test")
+    }
+  }
+
+  val failOnSuperfluousConfig = {
+    implicit def myDefaultNaming[A]: ConfigKeyNaming[A] =
+      ConfigKeyNaming.lowerCamelCase[A].or(ConfigKeyNaming.hyphenSeparated[A].apply)
+        .withFailOnSuperfluousKeys()
+    forAll {
+      val reader = ConfigReader.derive[ComplexClass]
+      val configStr = """
+          myAttr1 = test1
+          myAttr2 = test2
+          myAtrt3 = test3 // typo
+      """
+      val config = ConfigFactory.parseString(configStr)
+      val d = reader.extract(config)
+      d match {
+        case Failure(e) =>
+          // message should contain wrong attr,
+          e.messages.head.contains("myAtrt3") &&
+            e.messages.head.contains("myAttr3") && // similar attributes should be mentioned in error message
+            !e.messages.head.contains("other") // not enough similar attribute should not be mentioned in error message
+        case _ => false
+      }
+    }
+  }
+
+  val failOnSealedTraitSuperfluousConfig = {
+    // generic default naming
+    implicit def myDefaultNaming[A]: ConfigKeyNaming[A] =
+      ConfigKeyNaming.hyphenSeparated[A].or(ConfigKeyNaming.lowerCamelCase[A].apply)
+        .withFailOnSuperfluousKeys()
+    forAll {
+      val reader = ConfigReader.derive[TestSeal]
+      val configStr = """
+          type = Seal1
+          myAttr1 = test
+          my-attr-2 = test
+          myAttr3 = test // superfluous
+      """
+      val config = ConfigFactory.parseString(configStr)
+      val d = reader.extract(config)
+      d match {
+        case Failure(e) =>
+          // message should contain wrong attr,
+          e.messages.head.contains("myAttr3") &&
+            e.messages.head.contains("myAttr2") // similar attributes should be mentioned in error message
+        case _ => false
+      }
+    }
+  }
+
+  val failOnSealedTraitUnknownType = {
+    // generic default naming
+    implicit def myDefaultNaming[A]: ConfigKeyNaming[A] =
+      ConfigKeyNaming.hyphenSeparated[A].or(ConfigKeyNaming.lowerCamelCase[A].apply)
+        .withFailOnSuperfluousKeys()
+    forAll {
+      val reader = ConfigReader.derive[TestSeal]
+      val configStr = """
+          type = SealX // unknown
+          myAttr1 = test
+          my-attr2 = test
+      """
+      val config = ConfigFactory.parseString(configStr)
+      val d = reader.extract(config)
+      d match {
+        case Failure(e) => true
+        case _ => false
+      }
+    }
+  }
+
+  val failOnOptionalSealedTraitUnknownType = {
+    // generic default naming
+    implicit def myDefaultNaming[A]: ConfigKeyNaming[A] =
+      ConfigKeyNaming.hyphenSeparated[A].or(ConfigKeyNaming.lowerCamelCase[A].apply)
+        .withFailOnSuperfluousKeys()
+    forAll {
+      val reader = ConfigReader.derive[TestClass]
+      val configStr = """
+          my-attr-1 = test
+          myAttr2 = test
+          test-seal = {
+            type = SealX // unknown
+            myAttr1 = test
+            my-attr2 = test
+          }
+      """
+
+      val config = ConfigFactory.parseString(configStr)
+      val d = reader.extract(config)
+      d match {
+        case Failure(e) => true
+        case _ => false
+      }
+    }
+  }
+
+  val failOnOptionalSealedTraitSuperfluousConfig = {
+    // generic default naming
+    implicit def myDefaultNaming[A]: ConfigKeyNaming[A] =
+      ConfigKeyNaming.hyphenSeparated[A].or(ConfigKeyNaming.lowerCamelCase[A].apply)
+        .withFailOnSuperfluousKeys()
+    forAll {
+      val reader = ConfigReader.derive[TestClass]
+      val configStr = """
+          my-attr-1 = test
+          myAttr2 = test
+          test-seal = {
+            type = Seal1
+            myAttr1 = test
+            my-attr-2 = test
+            myAttr3 = test // superfluous
+          }
+      """
+      val config = ConfigFactory.parseString(configStr)
+      val d = reader.extract(config)
+      d match {
+        case Failure(e) =>
+          // message should contain wrong attr,
+          e.messages.head.contains("myAttr3") &&
+            e.messages.head.contains("myAttr2") // similar attributes should be mentioned in error message
+        case _ => false
+      }
     }
   }
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -14,6 +14,8 @@ object Common extends AutoPlugin {
 
     val lombok = "org.projectlombok" % "lombok" % "1.18.16"
 
+    val commonsText = "org.apache.commons" % "commons-text" % "1.9"
+
     val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
 
     val scalaReflect = Def.setting {


### PR DESCRIPTION
The change implements failing on superfluous keys in the config. This is very usable to detected potential typo's or also if configuration changed in new releases and attributes got deprecated and were finally removed. It can be enabled by configKeyNaming.withFailOnSuperfluousKeys(). In the error message i want to show potential similar attributes to help with typo's. To search for similar keys i use levenshtein distance from org.apache.commons:commons-text, which is a stable library with only a small number of dependencies.