### PR TITLE
fix scala 2.11 having problems finding default values of nested case classes because of uninitialized type metadata

### DIFF
--- a/core/src/main/scala/configs/macros/Construct.scala
+++ b/core/src/main/scala/configs/macros/Construct.scala
@@ -86,7 +86,8 @@ trait Construct {
     }
   }
 
-  private def defaults(a: ClassSymbol, m: MethodSymbol): Map[Int, ModuleMethod] =
+  private def defaults(a: ClassSymbol, m: MethodSymbol): Map[Int, ModuleMethod] = {
+    a.typeSignature // force initialize type metadata, otherwise some attributes are empty/false, e.g. isCaseClass, knownDirectSubclasses
     a.companion match {
       case cmp if cmp.isModule =>
         val mod = cmp.asModule
@@ -99,6 +100,7 @@ trait Construct {
         }.toMap
       case _ => Map.empty
     }
+  }
 
   private def caseClass(a: ClassSymbol, isSealedMember: Boolean = false): CaseClass = {
     val tpe = a.toType


### PR DESCRIPTION
Configs with scala 2.11 has problems finding default values of nested case classes. I had the following cases:
- a case class at 2nd level has an attribute "xyz: Option[Boolean] = Some(true)". A config without this attribute is parsed as "xyz = None", not respecting its default value.
- a case class at 2nd level has an attribute "xyz: Boolean = true". A config without this attribute throws an error that configuration for attribute "xyz" is missing. It seems that Configs doesn't know about its default value.

The strange thing about these errors is that they are not reproducible in unit tests of this project. I guess that it has to do with the numbers of macros that are generated in the project, and that scala optimizes loading of corresponding type metadata.

With this fix we can force scala to initialize type metadata before reading default values from it. This solves above cases.
